### PR TITLE
make `safe` safer

### DIFF
--- a/src/Control/Monad/Except/Checked.purs
+++ b/src/Control/Monad/Except/Checked.purs
@@ -49,4 +49,4 @@ safe
   . Functor m
   ⇒ ExceptV () m a
   → m a
-safe = unwrap >>> either case_ id
+safe = unwrap >>> map (either case_ id)

--- a/src/Control/Monad/Except/Checked.purs
+++ b/src/Control/Monad/Except/Checked.purs
@@ -14,10 +14,9 @@ module Control.Monad.Except.Checked
 import Prelude
 
 import Control.Monad.Except (ExceptT, lift, throwError)
-import Data.Either (either, fromRight)
+import Data.Either (either)
 import Data.Newtype (unwrap)
-import Data.Variant (class VariantMatchCases, Variant, onMatch)
-import Partial.Unsafe (unsafePartial)
+import Data.Variant (class VariantMatchCases, Variant, onMatch, case_)
 import Type.Row (class RowToList)
 
 type ExceptV exc = ExceptT (Variant exc)
@@ -50,4 +49,4 @@ safe
   . Functor m
   ⇒ ExceptV () m a
   → m a
-safe = unsafePartial $ unwrap >>> map fromRight
+safe = unwrap >>> either case_ id


### PR DESCRIPTION
`case_ ∷ ∀ a. Variant () → a`

`Variant ()` + `case_` is like `Void` + `absurd`

`Either Void a ~ a ~ Either (Variant ()) a`